### PR TITLE
Update Manifest for SDK version 28+

### DIFF
--- a/Diveboard/build.gradle
+++ b/Diveboard/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.2'
     }
 }
 

--- a/Diveboard/diveboard/src/main/AndroidManifest.xml
+++ b/Diveboard/diveboard/src/main/AndroidManifest.xml
@@ -34,7 +34,8 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/maps_app_id_debug" />
@@ -145,6 +146,7 @@
             android:name=".StatisticActivity"
             android:label="StatisticActivity"></activity>
         <uses-library android:name="org.apache.http.legacy" android:required="false" />
+
     </application>
 
 </manifest>

--- a/Diveboard/diveboard/src/main/AndroidManifest.xml
+++ b/Diveboard/diveboard/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <!-- To access Google+ APIs: -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
     <uses-permission android:name="android.permission.READ_LOGS" />
@@ -143,6 +144,7 @@
         <activity
             android:name=".StatisticActivity"
             android:label="StatisticActivity"></activity>
+        <uses-library android:name="org.apache.http.legacy" android:required="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
`READ_EXTERNAL_STORAGE` permission required for log in functionality.
`org.apache.http.legacy` library needs to be added to the manifest as off SDK 28+, see https://developers.google.com/maps/documentation/android-sdk/config#specify_requirement_for_apache_http_legacy_library
