### PR TITLE
Fix max depth on statistics page for dives with metric units

### DIFF
--- a/Diveboard/diveboard/src/main/java/com/diveboard/model/Dive.java
+++ b/Diveboard/diveboard/src/main/java/com/diveboard/model/Dive.java
@@ -532,7 +532,7 @@ public class Dive implements IModel {
             //prefer metric
             return Units.Distance.KM;
         }
-        return (rawUnits.compareTo("Km") == 0) ? Units.Distance.KM : Units.Distance.FT;
+        return (rawUnits.compareTo("m") == 0) ? Units.Distance.KM : Units.Distance.FT;
     }
 
     public void setMaxdepthUnit(String _maxdepth_unit) {


### PR DESCRIPTION
Dive depth is set in Meters but getting the max depth was checking if units were km, if not it's converting to ft. Meaning dives created with metric units always get converted to ft when retrieving max depth for statistics.

Before: (Max depth is incorrectly divided by 3.28084)

<img width="269" alt="image" src="https://user-images.githubusercontent.com/5101747/54479246-cf893e00-4812-11e9-9fda-24ab73aac802.png">

After: (Max depth is correct)

<img width="274" alt="image" src="https://user-images.githubusercontent.com/5101747/54479215-8c2ecf80-4812-11e9-8b0c-1e5ea752f615.png">
